### PR TITLE
Remove {i2extras}

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,7 +62,7 @@ episodes:
 - read-cases.Rmd
 - clean-data.Rmd
 - describe-cases.Rmd
-- simple-analysis.Rmd
+#- simple-analysis.Rmd
 
 # Information for Learners
 learners:

--- a/episodes/describe-cases.Rmd
+++ b/episodes/describe-cases.Rmd
@@ -222,7 +222,7 @@ base::plot(weekly_incidence_data) +
 
 ## Curve of cumulative cases
 
-The cumulative number of cases can calculated using `cumulate()` function from an `incidence2` object and visualize it, as in the below example.
+The cumulative number of cases can be calculated using the `cumulate()` function from an `incidence2` object and visualized, as in the example below.
 
 ```{r, message=FALSE, warning=FALSE}
 cum_df <- incidence2::cumulate(dialy_incidence_data)
@@ -234,11 +234,11 @@ base::plot(cum_df) +
   tracetheme::theme_trace()
 ```
 
-Note that this function preserve grouping, i.e., if the the `incidence2` object contains groups, then it will accumlate the cases accrodingly. 
+Note that this function preserves grouping, i.e., if the `incidence2` object contains groups, it will accumulate the cases accordingly. Give it a try with the `weekly_incidence_data` object!
 
 ##  Peak estimation
 
-One can estimate the peak --the time with highest number of recorded cases-- using `estimate_peak()` function from the {incidence2} package. 
+One can estimate the peak --the time with the highest number of recorded cases-- using the `estimate_peak()` function from the {incidence2} package. 
 This function employs a bootstrapping method to determine the peak time.
 
 ```{r, message=FALSE, warning=FALSE}

--- a/episodes/describe-cases.Rmd
+++ b/episodes/describe-cases.Rmd
@@ -214,11 +214,27 @@ base::plot(dialy_incidence_data) +
 
 base::plot(weekly_incidence_data) +
   ggplot2::labs(
-    x = "Time (in days)",
+    x = "Time (in weeks)",
     y = "weekly cases"
   ) +
   tracetheme::theme_trace()
 ``` 
+
+## Curve of cumulative cases
+
+The cumulative number of cases can calculated using `cumulate()` function from an `incidence2` object and visualize it, as in the below example.
+
+```{r, message=FALSE, warning=FALSE}
+cum_df <- incidence2::cumulate(dialy_incidence_data)
+base::plot(cum_df) +
+  ggplot2::labs(
+    x = "Time (in days)",
+    y = "weekly cases"
+  ) +
+  tracetheme::theme_trace()
+```
+
+Note that this function preserve grouping, i.e., if the the `incidence2` object contains groups, then it will accumlate the cases accrodingly. 
 
 ::::::::::::::::::::::::::::::::::::: challenge 
 

--- a/episodes/describe-cases.Rmd
+++ b/episodes/describe-cases.Rmd
@@ -28,8 +28,9 @@ This episode focuses on  EDA of outbreaks and epidemic data, and how to achieved
 packages. A key observation in EDA of epidemic analysis is capturing the relationship between time and the number of 
 reported cases, spanning various categories (confirmed, hospitalized, deaths, and recoveries), locations, and other 
 demographic factors such as gender, age, etc.  
- 
- ::::::::::::::::::: checklist
+
+
+::::::::::::::::::: checklist
 
 ### The double-colon
 

--- a/episodes/describe-cases.Rmd
+++ b/episodes/describe-cases.Rmd
@@ -236,6 +236,26 @@ base::plot(cum_df) +
 
 Note that this function preserve grouping, i.e., if the the `incidence2` object contains groups, then it will accumlate the cases accrodingly. 
 
+##  Peak estimation
+
+One can estimate the peak --the time with highest number of recorded cases-- using `estimate_peak()` function from the {incidence2} package. 
+This function employs a bootstrapping method to determine the peak time.
+
+```{r, message=FALSE, warning=FALSE}
+peak <- incidence2::estimate_peak(
+  dialy_incidence_data,
+  n = 100,
+  alpha = 0.05,
+  first_only = TRUE,
+  progress = FALSE
+)
+print(peak)
+```
+This example demonstrates how to estimate the peak time using the `estimate_peak()` function at $95%$ 
+confidence interval and using 100 bootstrap samples. 
+
+
+
 ::::::::::::::::::::::::::::::::::::: challenge 
 
 ## Challenge 1: Can you do it?

--- a/renv/profiles/lesson-requirements/renv.lock
+++ b/renv/profiles/lesson-requirements/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.4.0",
+    "Version": "4.4.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -407,7 +407,7 @@
       "Package": "cachem",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Requirements": [
         "fastmap",
         "rlang"
@@ -816,7 +816,7 @@
       "Package": "fastmap",
       "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Hash": "aa5e1cd11c2d15497494c5292d7ffcc8"
     },
     "fields": {
@@ -1878,7 +1878,7 @@
       "Package": "ragg",
       "Version": "1.3.2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://carpentries.r-universe.dev",
       "Requirements": [
         "systemfonts",
         "textshaping"
@@ -1999,7 +1999,7 @@
       "Package": "rio",
       "Version": "1.1.1",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "R.utils",
@@ -2022,7 +2022,7 @@
       "Package": "rlang",
       "Version": "1.1.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "utils"
@@ -2033,7 +2033,7 @@
       "Package": "rmarkdown",
       "Version": "2.27",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "bslib",
@@ -2103,7 +2103,7 @@
       "Package": "rstudioapi",
       "Version": "0.16.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Hash": "96710351d642b70e8f02ddeb237c46a7"
     },
     "runner": {
@@ -2319,7 +2319,7 @@
       "Package": "systemfonts",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://carpentries.r-universe.dev",
       "Requirements": [
         "R",
         "cpp11",
@@ -2371,7 +2371,7 @@
       "Package": "textshaping",
       "Version": "0.4.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://carpentries.r-universe.dev",
       "Requirements": [
         "R",
         "cpp11",
@@ -2493,7 +2493,7 @@
       "Package": "tinytex",
       "Version": "0.51",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/all/__linux__/jammy/latest",
       "Requirements": [
         "xfun"
       ],


### PR DESCRIPTION
This PR completely removes the usage of {i2extras}  from tutorials, and thus addressing issue #71. It also add section for calculating and visualizing the cumulative cases, and peak estimation.  