### PR TITLE
fixed some alt text and link descriptors flagged by pegboard

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -22,7 +22,7 @@ title: 'Glossary of Terms: Epiverse-TRACE'
 : The contact matrix is a square matrix consisting of rows/columns equal to the number age groups. Each element represents the frequency of contacts between age groups. If we believe that transmission of an infection is driven by contact, and that contact rates are very different for different age groups, then specifying a contact matrix allows us to account for age specific rates of transmission. 
 
 [C++]{#cplusplus}
-: C++ is a high-level programming language that can be used within R to speed up sections of code. To learn more about C++ check out these [tutorials](https://cplusplus.com/doc/tutorial/) and learn more about the integration of C++ and R [here](https://www.rcpp.org/).
+: C++ is a high-level programming language that can be used within R to speed up sections of code. To learn more about C++ check out these [tutorials](https://cplusplus.com/doc/tutorial/) and learn more about the integration of C++ and R in the [rcpp documentation](https://www.rcpp.org/).
 [Censoring]{#censoring}
 : 
 Means that we know an event happened, but we do not know exactly when it happened. Most epidemiological data are “doubly censored” because there is uncertainty surrounding both primary and secondary event times. Not accounting for censoring can lead to biased estimates of the delay’s standard deviation ([Park et al., in progress](https://github.com/parksw3/epidist-paper)).

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -22,7 +22,7 @@ title: 'Glossary of Terms: Epiverse-TRACE'
 : The contact matrix is a square matrix consisting of rows/columns equal to the number age groups. Each element represents the frequency of contacts between age groups. If we believe that transmission of an infection is driven by contact, and that contact rates are very different for different age groups, then specifying a contact matrix allows us to account for age specific rates of transmission. 
 
 [C++]{#cplusplus}
-: C++ is a high-level programming language that can be used within R to speed up sections of code. To learn more about C++ check out these [tutorials](https://cplusplus.com/doc/tutorial/) and learn more about the integration of C++ and R in the [rcpp documentation](https://www.rcpp.org/).
+: C++ is a high-level programming language that can be used within R to speed up sections of code. To learn more about C++ check out these [tutorials](https://cplusplus.com/doc/tutorial/) and learn more about the integration of C++ and R in the [Rcpp documentation](https://www.rcpp.org/).
 [Censoring]{#censoring}
 : 
 Means that we know an event happened, but we do not know exactly when it happened. Most epidemiological data are “doubly censored” because there is uncertainty surrounding both primary and secondary event times. Not accounting for censoring can lead to biased estimates of the delay’s standard deviation ([Park et al., in progress](https://github.com/parksw3/epidist-paper)).

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -37,13 +37,13 @@ Each episode contains:
 + **Challenges**: complete challenges to test your understanding.
 + **Explainers**: add to your understanding of mathematical and modelling concepts with the explainer boxes.
 
-Also check out the [glossary](../reference.md) for any terms you may be unfamiliar with.
+Also check out the [glossary](./reference.md) for any terms you may be unfamiliar with.
 
 ### Epiverse-TRACE R packages
 
 Our strategy is to gradually incorporate specialised **R packages** into a traditional analysis pipeline. These packages should fill the gaps in these epidemiology-specific tasks in response to outbreaks.
 
-![I](episodes/fig/pkgs-hexlogos-2.png).
+![I](episodes/fig/pkgs-hexlogos-2.png){alt='Outbreak analysis R packages hexagonal logos'}.
 
 <p><figure>
     <img src="episodes/fig/pkgs-hexlogos-2.png"


### PR DESCRIPTION
the current state of the lesson raises 
```
! There were errors in 3/167 links and images
◌ Some linked internal files do not exist <https://carpentries.github.io/sandpaper/articles/include-child-documents.html#workspace-consideration>
◌ Images need alt-text <https://webaim.org/techniques/hypertext/link_text#alt_link>
◌ Avoid uninformative link phrases <https://webaim.org/techniques/hypertext/link_text#uninformative>
```
when building the lesson. this PR fixes those small accessibility issues flagged